### PR TITLE
Change To The Build Process To Include libzstd.dll Automatically

### DIFF
--- a/REE.Unpacker/REE.Unpacker/REE.Unpacker.csproj
+++ b/REE.Unpacker/REE.Unpacker/REE.Unpacker.csproj
@@ -32,6 +32,14 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+  <!-- Copies libzstd.dll into the build folder manually because it's not directly referenced in the project. -->
+  <Target Name="CopyDLL" AfterTargets="Build">
+    <Message Text="copying libzstd.dll from $(SourceFolder)Libs\ to $(TargetDir)" Importance="High" />
+    <Copy SourceFiles="$(SourceFolder)Libs\libzstd.dll" DestinationFiles="$(TargetDir)libzstd.dll" SkipUnchangedFiles="true" />
+    <Message Text="copy successful" Importance="High" />
+  </Target>
+
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
- libzstd.dll is now automatically copied into the output directory of the build system if the newest version of it in \Libs isn't there already.

Just something to make the getting the tool running for the first time slightly easier for new folks, feel free to reject if you're not a fan 🥲 